### PR TITLE
HACK: drop search functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This should download sphinx (plus a few other dependencies). Note that you might
 To build the documentation and preview your changes, run
 
 ```
-make html
+make dirhtml
 ```
 
 from the main repo. The output files will show up in the `build` folder. Open these html files to explore the documentation locally.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 Sphinx
 awscli
-sphinxprettysearchresults

--- a/source/_templates/sticky.html
+++ b/source/_templates/sticky.html
@@ -1,4 +1,3 @@
 <div class="sticky">
-{% include "searchbox.html" %}
 {% include "relations.html" %}
 </div>

--- a/source/conf.py
+++ b/source/conf.py
@@ -37,7 +37,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'sphinx.ext.doctest',
-    'sphinxprettysearchresults',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
fixes #39 

---

## Notes

Before removing the search widget, I first tested doc-building in a new env, with the latest sphinx (3.0.3) - no dice. The URLs are actually even _more_ broken than as reported in #39, which was very disappointing.

I backtracked on that plan, and then removed the `sphinxprettysearchresults` extension and retested (just in case that extension was the cause) - no dice, same issue, even more broken URLs, broken in new ways.

That brings us to this proposed changeset - remove the search widget.