### PR TITLE
Updates from `source activate` to `conda activate`

### DIFF
--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -49,9 +49,9 @@ Activate the ``conda`` environment
 
 .. code-block:: bash
 
-    source activate qiime2-dev
+    conda activate qiime2-dev
     # to deactivate:
-    # source deactivate
+    # conda deactivate
     qiime info
 
 The output from ``qiime info`` should indicate that you have development versions of the QIIME 2 packages installed (the displayed versions will differ):

--- a/source/tutorials/conda-tutorial.rst
+++ b/source/tutorials/conda-tutorial.rst
@@ -280,7 +280,7 @@ https://dev.qiime2.org/latest/quickstart/)
 
     wget https://raw.githubusercontent.com/qiime2/environment-files/master/latest/staging/qiime2-latest-py35-osx-conda.yml
     conda env create -n qiime2-dev-condatest --file qiime2-latest-py35-osx-conda.yml
-    source activate qiime2-dev-condatest
+    conda activate qiime2-dev-condatest
 
 Then, you can just type in ``qiime`` to your command line and see if (1)
 you get no errors and (2) your plugin shows up in the list of available
@@ -378,7 +378,7 @@ qiime2.
 
 .. code:: bash
 
-    source activate qiime2-2019.1
+    conda activate qiime2-2019.1
     conda install -c cduvallet q2_perc_norm
 
 Another "gotcha!" that got me is that if you want to see which packages


### PR DESCRIPTION
This PR updates this repo's content to use the contemporary `conda activate`

Conda 4.6 was [released](https://www.anaconda.com/blog/conda-4-6-release) in June 2019, so `conda activate` has been [preferred by conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#activating-an-environment) over `source activate` for nearly a year. This command unifies the conda activation/deactivation UI across all platforms, so may reduce friction for conda users native to Windows. 