### PR TITLE
rm: removing q2studio references

### DIFF
--- a/source/getting-help.rst
+++ b/source/getting-help.rst
@@ -32,7 +32,7 @@ currently working on.
 .. _`QIIME 2 Forum`: https://forum.qiime2.org
 .. _`QIIME 2 repositories`: https://github.com/qiime2
 .. _`The QIIME 2 Framework`: https://github.com/qiime2/qiime2/
-.. _`Interfaces`: https://github.com/search?q=org%3Aqiime2+q2cli+OR+q2studio&type=Repositories
+.. _`Interfaces`: https://github.com/search?q=org%3Aqiime2+q2cli&type=Repositories
 .. _`Plugins`: https://github.com/qiime2?q=plugin+in%3Areadme
 .. _`@qiime2`: https://twitter.com/qiime2
 .. _`current release announcement`: https://forum.qiime2.org/tags/release

--- a/source/img/complex_component_diagram.svg
+++ b/source/img/complex_component_diagram.svg
@@ -51,7 +51,7 @@
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-873,-229)" stroke-linecap="butt">
       <rect fill="none" x="902.2" width="107" height="44.2" y="279.2" clip-path="url(#clipPath2)"/>
-      <text x="929.3094" xml:space="preserve" y="304.2121" clip-path="url(#clipPath2)" font-family="'Consolas'" stroke="none">q2studio</text>
+      <text x="929.3094" xml:space="preserve" y="304.2121" clip-path="url(#clipPath2)" font-family="'Consolas'" stroke="none">q2galaxy</text>
     </g>
     <g fill="white" text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-873,-229)" stroke="white">
       <rect x="1027.3" width="107" height="44.2" y="492.1" clip-path="url(#clipPath2)" stroke="none"/>

--- a/source/img/src/complex_component_diagram.graphml
+++ b/source/img/src/complex_component_diagram.graphml
@@ -123,7 +123,7 @@
           <y:Geometry height="44.19999999999993" width="107.0" x="902.2" y="279.20000000000033"/>
           <y:Fill color="#FFFFFF" transparent="false"/>
           <y:BorderStyle color="#000000" raised="false" type="line" width="1.0"/>
-          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Consolas" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="16.0" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="true" width="56.78125" x="25.109375" y="14.099999999999966">q2studio<y:LabelModel>
+          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Consolas" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="16.0" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="true" width="56.78125" x="25.109375" y="14.099999999999966">q2galaxy<y:LabelModel>
               <y:SmartNodeLabelModel distance="4.0"/>
             </y:LabelModel>
             <y:ModelParameter>
@@ -140,7 +140,7 @@
           <y:Geometry height="44.19999999999999" width="107.0" x="1027.300000000001" y="492.09999999999997"/>
           <y:Fill color="#FFFFFF" transparent="false"/>
           <y:BorderStyle color="#000000" raised="false" type="line" width="1.0"/>
-          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Consolas" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="28.0" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="true" width="83.171875" x="11.9140625" y="8.100000000000023">SDK 
+          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Consolas" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="28.0" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="true" width="83.171875" x="11.9140625" y="8.100000000000023">SDK
 &lt;qiime2.sdk&gt;<y:LabelModel>
               <y:SmartNodeLabelModel distance="4.0"/>
             </y:LabelModel>


### PR DESCRIPTION
this PR removes all references of q2studio from our developer docs and replaces it with q2studio in our architecture diagram