### PR TITLE
Swap requirements order

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@ Welcome to the QIIME 2 developer docs!
 
 To contribute, follow these steps:
 
-1. Fork this repo     
-2. Clone your forked repo onto your computer     
-3. Make a new branch      
+1. Fork this repo
+2. Clone your forked repo onto your computer
+3. Make a new branch
    `git checkout -b informative-branch-name`
-4. Make and preview your edits                
-5. Commit and push your edits, and start a pull request        
+4. Make and preview your edits
+5. Commit and push your edits, and start a pull request
 
 # Previewing edits
 
 This documentation is built by [sphinx](http://www.sphinx-doc.org/en/master/), which you can also use to make a local copy of the docs to preview on your computer.
 
-First, you need to have all the requirements download. From the main repo, run
+First, you need to have all of the required dependencies downloaded. From the main repo, run
 
 ```
 pip install -r requirements.txt
 ```
 
-This should download sphinx (plus a few other dependencies). Note that you might want to run this in a qiime2 dev environment, to keep installs separate from your main computer.
+This should download sphinx. Note that you might want to run this in a qiime2 dev environment, to keep installs separate from your main computer.
 
 To build the documentation and preview your changes, run
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-awscli
 sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx
 awscli
+sphinx


### PR DESCRIPTION
For some reason, when sphinx is the first requirement listed then `pip install -r requirements.txt` runs through an exhaustive search of awscli versions which takes a really long time. Swapping the order fixes the issue.

Tested:

```
pip install -r requirements.txt
make dirhtml
```

Which worked!